### PR TITLE
Add Psychology Laws Awesome to Cognitive Biases

### DIFF
--- a/README.md
+++ b/README.md
@@ -981,3 +981,5 @@ http://www.defmacro.org/2016/12/22/models.html
 https://en.wikipedia.org/wiki/List_of_cognitive_biases
 
 https://fs.blog/mental-models/
+
+- [Psychology Laws Awesome](https://github.com/daligao/psychology-laws-awesome) - 40 curated psychology laws and cognitive biases with interactive quiz. Bridges the gap between understanding concepts and recognizing them in real decisions.


### PR DESCRIPTION
## Add Psychology Laws Awesome

### What
Adding [psychology-laws-awesome](https://github.com/daligao/psychology-laws-awesome) to the Cognitive Biases section.

### Why
The Cognitive Biases section currently links to Wikipedia — psychology-laws-awesome complements this with an interactive, curated resource:

- 40 psychology laws and cognitive biases, organized by pattern
- Interactive quiz with 320+ real-world scenarios
- Data-driven: 8,000+ players, evidence-based error rates (72% Confirmation Bias, 68% Sunk Cost)
- Bridges the gap between understanding concepts and recognizing them in real decisions

### Quality
✅ All links verified
✅ MIT licensed
✅ Actively maintained
✅ No overlap with existing entries