### PR TITLE
Add Psychology Laws Awesome to Cognitive Biases section

### DIFF
--- a/README.md
+++ b/README.md
@@ -895,6 +895,8 @@ Thinking is a lot of work. “My first thought,” William Deresiewicz said in o
 
 https://en.wikipedia.org/wiki/List_of_cognitive_biases
 
+- [Psychology Laws Awesome](https://github.com/daligao/psychology-laws-awesome) - 40 curated psychology laws and cognitive biases with interactive quiz (320+ real-world scenarios) to bridge the gap between *understanding* a bias and *recognizing* it in practice. Built on 8,000+ player data.
+
 ## UX laws
 
 1. Aesthetic Usability Effect - Users often perceive aesthetically pleasing design as design that’s more usable.
@@ -981,5 +983,3 @@ http://www.defmacro.org/2016/12/22/models.html
 https://en.wikipedia.org/wiki/List_of_cognitive_biases
 
 https://fs.blog/mental-models/
-
-- [Psychology Laws Awesome](https://github.com/daligao/psychology-laws-awesome) - 40 curated psychology laws and cognitive biases with interactive quiz. Bridges the gap between understanding concepts and recognizing them in real decisions.

--- a/README.md
+++ b/README.md
@@ -981,3 +981,5 @@ http://www.defmacro.org/2016/12/22/models.html
 https://en.wikipedia.org/wiki/List_of_cognitive_biases
 
 https://fs.blog/mental-models/
+
+- [Psychology Laws Awesome](https://github.com/daligao/psychology-laws-awesome) - 40 curated psychology laws and cognitive biases with interactive quiz. Bridges the gap between understanding concepts and recognizing them in real decisions.


### PR DESCRIPTION
## Add Psychology Laws Awesome

### What

Adding [psychology-laws-awesome](https://github.com/daligao/psychology-laws-awesome) to the Cognitive Biases section.

### Why

The Cognitive Biases section currently links to Wikipedia's list, which explains biases conceptually. This project complements it with a practical recognition layer:

- **40 curated psychology laws and cognitive biases** organized by pattern
- **Interactive quiz with 320+ real-world scenarios** — unique teaching approach
- **Data-driven**: built on 8,000+ player feedback (72% misidentify Confirmation Bias even after reading about it)
- **Open source** (MIT) — accepting contributions
- **Active project**: https://ordinarymantrying.com/tools/mind-traps.html

### The gap this fills

Reading about a cognitive bias and *recognizing* it in a real situation are different skills. The quiz is specifically designed to train the recognition skill, not just the conceptual understanding.

### Quality checklist

- ✅ All links verified and working
- ✅ README clearly explains the project
- ✅ MIT license
- ✅ Actively maintained
- ✅ No overlap with existing entries (only adds one line after the Wikipedia link)

Thanks for considering!